### PR TITLE
Fix parsing and ToString not using invariant culture

### DIFF
--- a/src/netcore/EigenCore/Core/Dense/MatrixDenseBase.cs
+++ b/src/netcore/EigenCore/Core/Dense/MatrixDenseBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -203,7 +204,7 @@ namespace EigenCore.Core.Dense
                 {
                     for (int col = 0; col < Cols; col++)
                     {
-                        stringBuilder.AppendFormat("{0:G3} ", Get(row, col));
+                        stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:G3} ", Get(row, col));
                     }
                     stringBuilder.Append('\n');
                 }

--- a/src/netcore/EigenCore/Core/Dense/MatrixXD.cs
+++ b/src/netcore/EigenCore/Core/Dense/MatrixXD.cs
@@ -629,7 +629,7 @@ namespace EigenCore.Core.Dense
 
         }
 
-        public override MatrixXD Clone()
+        public override MatrixDenseBase<double> Clone()
         {
             return new MatrixXD(_values.ToArray(), Rows, Cols);
         }

--- a/src/netcore/EigenCore/Core/Dense/MatrixXD.cs
+++ b/src/netcore/EigenCore/Core/Dense/MatrixXD.cs
@@ -2,6 +2,7 @@
 using EigenCore.Core.Dense.LinearAlgebra;
 using EigenCore.Core.Shared;
 using EigenCore.Eigen;
+using System.Globalization;
 using System.Linq;
 
 namespace EigenCore.Core.Dense
@@ -685,7 +686,7 @@ namespace EigenCore.Core.Dense
         }
 
         public MatrixXD(string valuesString)
-            : base(valuesString, (string value) => double.Parse(value))
+            : base(valuesString, (string value) => double.Parse(value, CultureInfo.InvariantCulture))
         {
 
         }

--- a/src/netcore/EigenCore/Core/Dense/VBufferDense.cs
+++ b/src/netcore/EigenCore/Core/Dense/VBufferDense.cs
@@ -6,6 +6,11 @@ namespace EigenCore.Core.Dense
     {
         protected readonly T[] _values;
 
+        /// <summary>
+        /// Use only for reading raw data efficiently.
+        /// </summary>
+        public T[] Values => _values;
+
         public readonly int Length;
 
         public ReadOnlySpan<T> GetValues() => _values.AsSpan(0, Length);

--- a/src/netcore/EigenCore/Core/Dense/VectorDenseBase.cs
+++ b/src/netcore/EigenCore/Core/Dense/VectorDenseBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -80,7 +81,7 @@ namespace EigenCore.Core.Dense
                     return stringBuilder.ToString().Trim();
                 }
 
-                stringBuilder.AppendFormat("{0:G3} ", _values[i]);
+                stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:G3} ", _values[i]);
             }
 
             return stringBuilder.ToString().Trim();

--- a/src/netcore/EigenCore/Core/Dense/VectorXD.cs
+++ b/src/netcore/EigenCore/Core/Dense/VectorXD.cs
@@ -1,6 +1,7 @@
 ﻿using EigenCore.Core.Shared;
 using EigenCore.Eigen;
 using System;
+using System.Globalization;
 using System.Linq;
 
 namespace EigenCore.Core.Dense
@@ -149,7 +150,7 @@ namespace EigenCore.Core.Dense
         }
 
         public VectorXD(string valuesString)
-            : base(valuesString, (string value) => double.Parse(value))
+            : base(valuesString, (string value) => double.Parse(value, CultureInfo.InvariantCulture))
         {
         }
 

--- a/src/netcore/EigenCore/Core/Sparse/MatrixSparseBase.cs
+++ b/src/netcore/EigenCore/Core/Sparse/MatrixSparseBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -143,7 +144,7 @@ namespace EigenCore.Core.Sparse
                 {
                     for (int col = 0; col < Cols; col++)
                     {
-                        stringBuilder.AppendFormat("{0:G3} ", Get(row, col));
+                        stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:G3} ", Get(row, col));
                     }
                     stringBuilder.Append('\n');
                 }

--- a/src/netcore/EigenCore/Core/Sparse/VectorSparseBase.cs
+++ b/src/netcore/EigenCore/Core/Sparse/VectorSparseBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -79,7 +80,7 @@ namespace EigenCore.Core.Sparse
                     return stringBuilder.ToString().Trim();
                 }
 
-                stringBuilder.AppendFormat("{0:G3} ", Get(i));
+                stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "{0:G3} ", Get(i));
             }
 
             return stringBuilder.ToString().Trim();

--- a/src/netcore/EigenCore/EigenCore.csproj
+++ b/src/netcore/EigenCore/EigenCore.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <Product />
     <Company />
     <Authors>modios</Authors>
-    <Version>1.0.0-alpha</Version>
+    <Version>1.0.2-alpha</Version>
     <Description>.Net wrapper for the Eigen C++ library</Description>
     <Copyright>modios</Copyright>
     <RepositoryUrl>https://github.com/modios/EigenCore</RepositoryUrl>


### PR DESCRIPTION
Needef for parsing matrices from strings in locales where the dot and comma are switched for decimal signs (eg germany). Currently this fails. To match this, I also changed the ToString methods.